### PR TITLE
fix: allow empty subDiagrams in VisualPage to prevent rendering issues

### DIFF
--- a/packages/mermaid/src/diagrams/visslides/renderer.ts
+++ b/packages/mermaid/src/diagrams/visslides/renderer.ts
@@ -172,6 +172,12 @@ const draw: DrawDefinition = (_text, id, _version, diagram: Diagram) => {
 
     let yOffset = 50;
 
+    // If the page has no subDiagrams, just leave it empty (but still render the group)
+    if (!page.subDiagrams || page.subDiagrams.length === 0) {
+      // Optionally, you could add a placeholder or leave it truly empty
+      return;
+    }
+
     for (const subDiagram of page.subDiagrams) {
       if ((subDiagram as ArrayDiagram).elements) {
         drawArrayDiagram(pageGroup as unknown as SVG, subDiagram as ArrayDiagram, yOffset, config);

--- a/packages/parser/src/language/visual/visual.langium
+++ b/packages/parser/src/language/visual/visual.langium
@@ -11,7 +11,7 @@ entry VisualDiagram:
 VisualPage:
   "page" NEWLINE*
   ('layout:' layout=LayoutDefinition NEWLINE*)?
-  subDiagrams+=SubDiagram+
+  subDiagrams+=SubDiagram*
 ;
 
 SubDiagram:


### PR DESCRIPTION
Fixes [merlin#21](https://github.com/ETH-PEACH-Lab/merlin/issues/26) allowing empty pages