### PR TITLE
Feat/implement new tree syntax

### DIFF
--- a/packages/mermaid/src/diagrams/visual/drawTreeDiagram.ts
+++ b/packages/mermaid/src/diagrams/visual/drawTreeDiagram.ts
@@ -1,7 +1,9 @@
-import type { TreeDiagram } from './types.js';
+import type { TreeDiagram, TreeNodeDefinition, TreeChildDefinition } from './types.js';
 import type { SVG } from '../../diagram-api/types.js';
 import { getColor } from './getColor.js';
 import { formatValue, shouldDisplayArrowLabel } from './valueFormatter.js';
+
+const MAX_CHILDREN_PER_NODE = 10;
 
 export const drawTreeDiagram = (svg: SVG, treeDiagram: TreeDiagram, component_id: number) => {
   const group = svg.append('g');
@@ -22,32 +24,74 @@ export const drawTreeDiagram = (svg: SVG, treeDiagram: TreeDiagram, component_id
     .attr('d', 'M 0 0 L 10 5 L 0 10 z')
     .attr('fill', 'black');
 
-  const treeNodes = treeDiagram.elements || [];
-  const treeEdges = calculateTreeEdges(treeNodes);
+  const elements = treeDiagram.elements || [];
 
-  // Calculate node positions in a tree layout
-  const nodePositions = calculateNodePositions(treeNodes);
+  // Parse nodes and children from elements
+  const nodes: TreeNodeDefinition[] = [];
+  const childRelations: TreeChildDefinition[] = [];
 
-  // Draw tree edges first
-  if (treeEdges) {
-    treeEdges.forEach((edge) => {
-      drawEdge(group as unknown as SVG, edge, nodePositions);
-    });
+  elements.forEach((element) => {
+    if (element.nodeDefinition) {
+      nodes.push(element.nodeDefinition);
+    }
+    if (element.childDefinition) {
+      childRelations.push(element.childDefinition);
+    }
+  });
+
+  // Check for excessive children per node
+  const childCounts = new Map<string, number>();
+  childRelations.forEach((relation) => {
+    const count = childCounts.get(relation.parent) || 0;
+    childCounts.set(relation.parent, count + 1);
+  });
+
+  const maxChildren = Math.max(...[...childCounts.values()], 0);
+  if (maxChildren > MAX_CHILDREN_PER_NODE) {
+    // Show warning instead of the diagram
+    group
+      .append('text')
+      .attr('x', 100)
+      .attr('y', 50)
+      .attr('fill', '#faa')
+      .attr('font-size', '16')
+      .attr('text-anchor', 'start')
+      .text(
+        `Warning: Node has ${maxChildren} children (max recommended: ${MAX_CHILDREN_PER_NODE})`
+      );
+    return;
   }
 
-  // Draw tree nodes
-  if (treeNodes) {
-    let unit_id = 0;
-    treeNodes.forEach((node) => {
-      drawNode(group as unknown as SVG, node, nodePositions[node.nodeId], unit_id);
+  // Build tree structure
+  const treeStructure = buildTreeStructure(nodes, childRelations);
+
+  if (treeStructure.length === 0) {
+    return;
+  }
+
+  // Calculate node positions
+  const nodePositions = calculateNodePositions(treeStructure, childRelations, nodes);
+
+  // Draw edges first
+  childRelations.forEach((relation) => {
+    drawEdge(group as unknown as SVG, relation, nodePositions);
+  });
+
+  // Draw nodes
+  let unit_id = 0;
+  nodes.forEach((node) => {
+    const position = nodePositions[node.nodeId];
+    if (position) {
+      drawNode(group as unknown as SVG, node, position, unit_id);
       unit_id += 1;
-    });
-  }
+    }
+  });
 
   if (treeDiagram.label) {
     // Add the label at the bottom
-    const labelYPosition = treeNodes ? Math.ceil(treeNodes.length / 3) * 100 + 70 : 100;
-    const labelXPosition = 150; // Adjust based on your diagram size and layout
+    const maxY = Math.max(...Object.values(nodePositions).map((pos) => pos.y));
+    const labelYPosition = maxY + 70;
+    const labelXPosition = 150;
 
     group
       .append('text')
@@ -62,71 +106,126 @@ export const drawTreeDiagram = (svg: SVG, treeDiagram: TreeDiagram, component_id
   }
 };
 
-const calculateNodePositions = (nodes: any[]): { [key: string]: { x: number; y: number } } => {
+const buildTreeStructure = (nodes: TreeNodeDefinition[], childRelations: TreeChildDefinition[]) => {
+  // Find root nodes (nodes that are not children of any other node)
+  const childNodeIds = new Set(childRelations.map((rel) => rel.child));
+  return nodes.filter((node) => !childNodeIds.has(node.nodeId));
+};
+
+const calculateNodePositions = (
+  rootNodes: TreeNodeDefinition[],
+  childRelations: TreeChildDefinition[],
+  nodes: TreeNodeDefinition[]
+): { [key: string]: { x: number; y: number } } => {
   const positions: { [key: string]: { x: number; y: number } } = {};
   const levelHeight = 100;
-  const maxDepth = calculateMaxDepth(nodes);
-  const maxDistance = maxDepth > 2 ? 100 : 70; // Adjust this value based on the total number of layers
-  const currentY = 0;
+  const svgWidth = 959; // match your default SVG width
+  const svgHeight = 400; // match your default SVG height
+  const baseWidth = svgWidth - 100; // leave some margin
 
-  const calculatePosition = (node: any, currentX: number, depth: number) => {
-    const adjustedSiblingDistance = maxDistance - depth * (maxDistance / maxDepth);
-    const x = currentX;
-    const y = currentY + depth * levelHeight;
-    positions[node.nodeId] = { x, y };
+  if (rootNodes.length === 0) {
+    return positions;
+  }
 
-    const leftChild = nodes.find((n) => n.nodeId === node.left);
-    const rightChild = nodes.find((n) => n.nodeId === node.right);
-    if (leftChild) {
-      calculatePosition(leftChild, x - adjustedSiblingDistance, depth + 1);
+  // Start with the first root node
+  const rootNode = rootNodes[0];
+
+  // Helper to get node definition by id
+  const nodeById = (id: string) => [...rootNodes, ...nodes].find((n) => n.nodeId === id);
+
+  // Estimate width for arrow label based on text length and font size
+  const estimateArrowLabelWidth = (label: string | undefined) => {
+    if (!label) {
+      return 0;
     }
-    if (rightChild) {
-      calculatePosition(rightChild, x + adjustedSiblingDistance, depth + 1);
-    }
+    const avgCharWidth = 10; // px, rough estimate for font-size 14-16
+    return label.length * avgCharWidth + 16; // add some padding
   };
 
-  const rootNode = nodes.find((node) => !node.parentId);
-  if (rootNode) {
-    calculatePosition(rootNode, 150, 0); // Start from the center horizontally
-  }
+  const calculateSubtreeWidth = (nodeId: string, depth: number): number => {
+    const children = childRelations.filter((rel) => rel.parent === nodeId);
+    const baseWidth = 50;
+    const node = nodeById(nodeId);
+    let extraWidth = 0;
+    if (children.length === 0) {
+      // If this node has an arrow label, reserve extra width to the right
+      if (node && node.arrow && shouldDisplayArrowLabel(node.arrowLabel)) {
+        extraWidth = estimateArrowLabelWidth(node.arrowLabel ? String(node.arrowLabel) : '');
+      }
+      return baseWidth + extraWidth;
+    }
+
+    let totalChildrenWidth = 0;
+    children.forEach((child) => {
+      totalChildrenWidth += calculateSubtreeWidth(child.child, depth + 1);
+    });
+
+    // If this node has an arrow label, reserve extra width to the right (for centering correction)
+    if (node && node.arrow && shouldDisplayArrowLabel(node.arrowLabel)) {
+      extraWidth = estimateArrowLabelWidth(node.arrowLabel ? String(node.arrowLabel) : '');
+    }
+
+    return Math.max(baseWidth, totalChildrenWidth + (children.length - 1) * 20) + extraWidth;
+  };
+
+  const calculatePosition = (
+    nodeId: string,
+    x: number,
+    y: number,
+    availableWidth: number,
+    isRoot = false
+  ) => {
+    // If this node has an arrow label, shift center to the left by half the extra width, unless it's the root
+    const node = nodeById(nodeId);
+    let extraWidth = 0;
+    if (!isRoot && node && node.arrow && shouldDisplayArrowLabel(node.arrowLabel)) {
+      extraWidth = estimateArrowLabelWidth(node.arrowLabel ? String(node.arrowLabel) : '');
+    }
+    const nodeCenterX = x - extraWidth / 2;
+    positions[nodeId] = { x: nodeCenterX, y };
+
+    const children = childRelations.filter((rel) => rel.parent === nodeId);
+    if (children.length === 0) {
+      return;
+    }
+
+    // Calculate width needed for each child subtree
+    const childWidths = children.map((child) => calculateSubtreeWidth(child.child, 0));
+    const totalChildrenWidth = childWidths.reduce((sum, width) => sum + width, 0);
+    // No extra spacing between subtrees, just a minimal gap
+    const minGap = 20;
+    const totalGap = Math.max(minGap * (children.length - 1), availableWidth - totalChildrenWidth);
+    const gap = children.length > 1 ? totalGap / (children.length - 1) : 0;
+
+    // Start at left edge of availableWidth
+    let currentX = x - availableWidth / 2;
+
+    children.forEach((child, index) => {
+      // Center the child in its subtree width
+      const childX = currentX + childWidths[index] / 2;
+      const childY = y + levelHeight;
+
+      calculatePosition(child.child, childX, childY, childWidths[index], false);
+      currentX += childWidths[index] + gap;
+    });
+  };
+
+  // Center the root node horizontally in the SVG
+  const rootWidth = calculateSubtreeWidth(rootNode.nodeId, 0);
+  const usedWidth = Math.min(rootWidth, baseWidth);
+  const rootX = svgWidth / 2;
+  const rootY = 50;
+  calculatePosition(rootNode.nodeId, rootX, rootY, usedWidth, true);
 
   return positions;
 };
 
-const calculateMaxDepth = (nodes: any[]): number => {
-  const findDepth = (node: any, depth: number): number => {
-    const leftChild = nodes.find((n) => n.nodeId === node.left);
-    const rightChild = nodes.find((n) => n.nodeId === node.right);
-    const leftDepth = leftChild ? findDepth(leftChild, depth + 1) : depth;
-    const rightDepth = rightChild ? findDepth(rightChild, depth + 1) : depth;
-    return Math.max(leftDepth, rightDepth);
-  };
-
-  const rootNode = nodes.find((node) => !node.parentId);
-  if (rootNode) {
-    return findDepth(rootNode, 0);
-  }
-  return 0;
-};
-
-const calculateTreeEdges = (
-  nodes: any[]
-): { start: string; end: string; value?: string; color?: string }[] => {
-  const edges: { start: string; end: string; value?: string; color?: string }[] = [];
-
-  nodes.forEach((node) => {
-    if (node.left) {
-      edges.push({ start: node.nodeId, end: node.left });
-    }
-    if (node.right) {
-      edges.push({ start: node.nodeId, end: node.right });
-    }
-  });
-
-  return edges;
-};
-
-const drawNode = (svg: SVG, node: any, position: { x: number; y: number }, unit_id: number) => {
+const drawNode = (
+  svg: SVG,
+  node: TreeNodeDefinition,
+  position: { x: number; y: number },
+  unit_id: number
+) => {
   const nodeX = position.x;
   const nodeY = position.y;
 
@@ -145,38 +244,146 @@ const drawNode = (svg: SVG, node: any, position: { x: number; y: number }, unit_
     .attr('stroke-width', '1')
     .attr('class', 'treeNode');
 
-  group
-    .append('text')
-    .attr('x', nodeX)
-    .attr('y', nodeY)
-    .attr('dy', '.35em')
-    .attr('fill', 'black')
-    .attr('font-size', '16')
-    .attr('dominant-baseline', 'middle')
-    .attr('text-anchor', 'middle')
-    .attr('class', 'nodeLabel')
-    .text(formatValue(node.value || node.nodeId));
+  // Dynamically scale down the font size to minimum, then split in the middle recursively if still too wide
+  const valueText = formatValue(node.value || node.nodeId);
+  let fontSize = 16;
+  const minFontSize = 9;
+  const maxTextWidth = 32; // slightly less than diameter (40) for padding
+  // Helper to measure text width
+  function measureTextWidth(text: string, fontSize: number) {
+    const tempText = svg
+      .append('text')
+      .attr('x', -9999)
+      .attr('y', -9999)
+      .attr('font-size', fontSize)
+      .attr('font-family', 'sans-serif')
+      .text(text);
+    let width = 0;
+    const tempNode = tempText.node();
+    if (tempNode) {
+      width = tempNode.getBBox().width;
+    }
+    tempText.remove();
+    return width;
+  }
+
+  // First, try to fit the text by scaling down font size to minFontSize
+  let lines = [valueText];
+  let fits = false;
+  while (!fits && fontSize >= minFontSize) {
+    const width = measureTextWidth(valueText, fontSize);
+    if (width <= maxTextWidth) {
+      fits = true;
+      break;
+    }
+    fontSize -= 1;
+  }
+
+  // If still doesn't fit at minFontSize, split recursively in the middle
+  function splitLineRecursively(line: string, fontSize: number): string[] {
+    if (measureTextWidth(line, fontSize) <= maxTextWidth || line.length <= 1) {
+      return [line];
+    }
+    // Find a split point near the middle, prefer splitting at a space
+    const mid = Math.floor(line.length / 2);
+    let splitIdx = mid;
+    // Look for a space to split on, first right, then left
+    for (let offset = 0; offset < mid; offset++) {
+      if (line[mid + offset] === ' ') {
+        splitIdx = mid + offset;
+        break;
+      } else if (line[mid - offset] === ' ') {
+        splitIdx = mid - offset;
+        break;
+      }
+    }
+    // If no space found, split at mid
+    if (line[splitIdx] === ' ') {
+      // Don't include the space at the start of the next line
+      return [line.slice(0, splitIdx), line.slice(splitIdx + 1)].flatMap((l) =>
+        splitLineRecursively(l, fontSize)
+      );
+    } else {
+      return [line.slice(0, splitIdx), line.slice(splitIdx)].flatMap((l) =>
+        splitLineRecursively(l, fontSize)
+      );
+    }
+  }
+
+  if (!fits) {
+    lines = splitLineRecursively(valueText, fontSize);
+    // After splitting, check if any line is still too wide, and if so, split again recursively
+    let allFit = false;
+    while (!allFit) {
+      allFit = true;
+      const newLines: string[] = [];
+      for (const line of lines) {
+        if (measureTextWidth(line, fontSize) > maxTextWidth && line.length > 1) {
+          allFit = false;
+          newLines.push(...splitLineRecursively(line, fontSize));
+        } else {
+          newLines.push(line);
+        }
+      }
+      lines = newLines;
+    }
+  }
+
+  // Draw the text, centered vertically (fix for single-line centering)
+  if (lines.length === 1) {
+    // For one line, center exactly at nodeY using dy='0' for perfect vertical alignment
+    group
+      .append('text')
+      .attr('x', nodeX)
+      .attr('y', nodeY)
+      .attr('dy', '.1em')
+      .attr('fill', 'black')
+      .attr('font-size', fontSize)
+      .attr('font-family', 'sans-serif')
+      .attr('dominant-baseline', 'middle')
+      .attr('text-anchor', 'middle')
+      .attr('class', 'nodeLabel')
+      .text(lines[0]);
+  } else {
+    // For multiple lines, center block
+    const totalHeight = lines.length * fontSize * 1.1;
+    const startY = nodeY - totalHeight / 2 + fontSize * 0.85;
+    lines.forEach((line, i) => {
+      group
+        .append('text')
+        .attr('x', nodeX)
+        .attr('y', startY + i * fontSize * 1.1)
+        .attr('fill', 'black')
+        .attr('font-size', fontSize)
+        .attr('font-family', 'sans-serif')
+        .attr('dominant-baseline', 'middle')
+        .attr('text-anchor', 'middle')
+        .attr('class', 'nodeLabel')
+        .text(line);
+    });
+  }
 
   // Draw the arrow on the right side of the node, pointing towards the node
   if (node.arrow && shouldDisplayArrowLabel(node.arrowLabel)) {
-    const arrowXStart = nodeX + 45; // Move further right to avoid overlap
-    const arrowXEnd = nodeX + 25; // End near the node edge
+    // Always draw the arrow perfectly horizontal
+    const arrowXStart = Math.round(nodeX + 45);
+    const arrowXEnd = Math.round(nodeX + 25);
+    const arrowY = Math.round(nodeY);
 
     group
       .append('line')
       .attr('x1', arrowXStart)
-      .attr('y1', nodeY)
+      .attr('y1', arrowY)
       .attr('x2', arrowXEnd)
-      .attr('y2', nodeY)
+      .attr('y2', arrowY)
       .attr('stroke', 'black')
       .attr('stroke-width', '2')
       .attr('marker-end', 'url(#arrowhead)');
 
-    // Draw the arrow label if it exists
     group
       .append('text')
       .attr('x', arrowXStart + 5)
-      .attr('y', nodeY) // Place the label slightly above the arrow
+      .attr('y', arrowY)
       .attr('fill', 'black')
       .attr('font-size', '16')
       .attr('dominant-baseline', 'middle')
@@ -188,19 +395,14 @@ const drawNode = (svg: SVG, node: any, position: { x: number; y: number }, unit_
 
 const drawEdge = (
   svg: SVG,
-  edge: { start: string; end: string; value?: string; color?: string },
+  relation: TreeChildDefinition,
   nodePositions: { [key: string]: { x: number; y: number } }
 ) => {
-  const startNodePosition = nodePositions[edge.start];
-  const endNodePosition = nodePositions[edge.end];
+  const parentPosition = nodePositions[relation.parent];
+  const childPosition = nodePositions[relation.child];
 
-  if (startNodePosition && endNodePosition) {
-    const { startX, startY, endX, endY } = calculateEdgePosition(
-      startNodePosition,
-      endNodePosition
-    );
-
-    const strokeColor = edge.color || 'black';
+  if (parentPosition && childPosition) {
+    const { startX, startY, endX, endY } = calculateEdgePosition(parentPosition, childPosition);
 
     svg
       .append('line')
@@ -208,21 +410,8 @@ const drawEdge = (
       .attr('y1', startY)
       .attr('x2', endX)
       .attr('y2', endY)
-      .attr('stroke', strokeColor)
+      .attr('stroke', 'black')
       .attr('stroke-width', '2');
-
-    if (edge.value) {
-      svg
-        .append('text')
-        .attr('x', (startX + endX) / 2)
-        .attr('y', (startY + endY) / 2)
-        .attr('fill', 'black')
-        .attr('font-size', '16')
-        .attr('dominant-baseline', 'middle')
-        .attr('text-anchor', 'middle')
-        .attr('class', 'edgeLabel')
-        .text(formatValue(edge.value));
-    }
   }
 };
 
@@ -230,8 +419,9 @@ const calculateEdgePosition = (start: { x: number; y: number }, end: { x: number
   const radius = 20; // Radius of the nodes
   const deltaX = end.x - start.x;
   const deltaY = end.y - start.y;
-  const distance = Math.sqrt(deltaX * deltaX + deltaY * deltaY);
 
+  // For angled lines, calculate proper offsets
+  const distance = Math.sqrt(deltaX * deltaX + deltaY * deltaY);
   const offsetX = (deltaX * radius) / distance;
   const offsetY = (deltaY * radius) / distance;
 

--- a/packages/mermaid/src/diagrams/visual/drawTreeDiagram.ts
+++ b/packages/mermaid/src/diagrams/visual/drawTreeDiagram.ts
@@ -138,34 +138,27 @@ const calculateNodePositions = (
     if (!label) {
       return 0;
     }
-    const avgCharWidth = 10; // px, rough estimate for font-size 14-16
+    const avgCharWidth = 16; // px, rough estimate for font-size 14-16
     return label.length * avgCharWidth + 16; // add some padding
   };
 
-  const calculateSubtreeWidth = (nodeId: string, depth: number): number => {
+  const calculateSubtreeWidth = (nodeId: string, depth: number, parentId?: string): number => {
     const children = childRelations.filter((rel) => rel.parent === nodeId);
     const baseWidth = 50;
-    const node = nodeById(nodeId);
-    let extraWidth = 0;
+
     if (children.length === 0) {
-      // If this node has an arrow label, reserve extra width to the right
-      if (node && node.arrow && shouldDisplayArrowLabel(node.arrowLabel)) {
-        extraWidth = estimateArrowLabelWidth(node.arrowLabel ? String(node.arrowLabel) : '');
-      }
-      return baseWidth + extraWidth;
+      // For leaf nodes, always use base width to ensure consistent subtree calculations
+      // Arrow positioning will be handled separately to avoid overlaps
+      return baseWidth;
     }
 
+    // For nodes with children, calculate based purely on children's subtree widths
     let totalChildrenWidth = 0;
     children.forEach((child) => {
-      totalChildrenWidth += calculateSubtreeWidth(child.child, depth + 1);
+      totalChildrenWidth += calculateSubtreeWidth(child.child, depth + 1, nodeId);
     });
 
-    // If this node has an arrow label, reserve extra width to the right (for centering correction)
-    if (node && node.arrow && shouldDisplayArrowLabel(node.arrowLabel)) {
-      extraWidth = estimateArrowLabelWidth(node.arrowLabel ? String(node.arrowLabel) : '');
-    }
-
-    return Math.max(baseWidth, totalChildrenWidth + (children.length - 1) * 20) + extraWidth;
+    return Math.max(baseWidth, totalChildrenWidth + (children.length - 1) * 20);
   };
 
   const calculatePosition = (
@@ -175,14 +168,8 @@ const calculateNodePositions = (
     availableWidth: number,
     isRoot = false
   ) => {
-    // If this node has an arrow label, shift center to the left by half the extra width, unless it's the root
-    const node = nodeById(nodeId);
-    let extraWidth = 0;
-    if (!isRoot && node && node.arrow && shouldDisplayArrowLabel(node.arrowLabel)) {
-      extraWidth = estimateArrowLabelWidth(node.arrowLabel ? String(node.arrowLabel) : '');
-    }
-    const nodeCenterX = x - extraWidth / 2;
-    positions[nodeId] = { x: nodeCenterX, y };
+    // Position the node at the center of its available space
+    positions[nodeId] = { x, y };
 
     const children = childRelations.filter((rel) => rel.parent === nodeId);
     if (children.length === 0) {
@@ -190,11 +177,30 @@ const calculateNodePositions = (
     }
 
     // Calculate width needed for each child subtree
-    const childWidths = children.map((child) => calculateSubtreeWidth(child.child, 0));
+    const childWidths = children.map((child) => calculateSubtreeWidth(child.child, 0, nodeId));
     const totalChildrenWidth = childWidths.reduce((sum, width) => sum + width, 0);
-    // No extra spacing between subtrees, just a minimal gap
+
+    // Calculate additional spacing needed for arrow labels
+    let totalArrowWidth = 0;
+    const childNodes = children.map((child) => nodeById(child.child));
+    childNodes.forEach((childNode, index) => {
+      if (
+        childNode &&
+        childNode.arrow &&
+        shouldDisplayArrowLabel(childNode.arrowLabel) && // Add arrow width only if there's a next sibling that could be affected
+        index < childNodes.length - 1
+      ) {
+        totalArrowWidth += estimateArrowLabelWidth(
+          childNode.arrowLabel ? String(childNode.arrowLabel) : ''
+        );
+      }
+    });
+
+    // Base gap between children
     const minGap = 20;
-    const totalGap = Math.max(minGap * (children.length - 1), availableWidth - totalChildrenWidth);
+    // Total gap needed including space for arrows
+    const neededGap = (children.length - 1) * minGap + totalArrowWidth;
+    const totalGap = Math.max(neededGap, availableWidth - totalChildrenWidth);
     const gap = children.length > 1 ? totalGap / (children.length - 1) : 0;
 
     // Start at left edge of availableWidth
@@ -210,9 +216,35 @@ const calculateNodePositions = (
     });
   };
 
-  // Center the root node horizontally in the SVG
-  const rootWidth = calculateSubtreeWidth(rootNode.nodeId, 0);
-  const usedWidth = Math.min(rootWidth, baseWidth);
+  // Calculate root width including space for any arrow labels at the top level
+  const rootChildren = childRelations.filter((rel) => rel.parent === rootNode.nodeId);
+  let rootArrowWidth = 0;
+
+  // Add space for root's own arrow if it has one
+  if (rootNode.arrow && shouldDisplayArrowLabel(rootNode.arrowLabel)) {
+    rootArrowWidth += estimateArrowLabelWidth(
+      rootNode.arrowLabel ? String(rootNode.arrowLabel) : ''
+    );
+  }
+
+  // Add space for children's arrows that might extend to the right
+  const rootChildNodes = rootChildren.map((child) => nodeById(child.child));
+  rootChildNodes.forEach((childNode, index) => {
+    if (
+      childNode &&
+      childNode.arrow &&
+      shouldDisplayArrowLabel(childNode.arrowLabel) &&
+      index < rootChildNodes.length - 1
+    ) {
+      rootArrowWidth += estimateArrowLabelWidth(
+        childNode.arrowLabel ? String(childNode.arrowLabel) : ''
+      );
+    }
+  });
+
+  const baseSubtreeWidth = calculateSubtreeWidth(rootNode.nodeId, 0, undefined);
+  const rootWidth = baseSubtreeWidth + rootArrowWidth;
+  const usedWidth = Math.min(rootWidth, baseWidth + rootArrowWidth);
   const rootX = svgWidth / 2;
   const rootY = 50;
   calculatePosition(rootNode.nodeId, rootX, rootY, usedWidth, true);

--- a/packages/mermaid/src/diagrams/visual/parser.ts
+++ b/packages/mermaid/src/diagrams/visual/parser.ts
@@ -111,15 +111,29 @@ const populate = (ast: VisualDiagram) => {
             title: subDiagram.diagramTitle,
             position: processPosition(subDiagram.position),
             label: subDiagram.label,
-            elements: subDiagram.elements.map((element: any) => ({
-              nodeId: element.nodeId,
-              left: element.left == 'None' ? undefined : element.left,
-              right: element.right == 'None' ? undefined : element.right,
-              value: element.value,
-              color: element.color,
-              arrow: element.arrowLabel !== undefined && element.arrowLabel !== null, //if with arrow then True, else False
-              arrowLabel: element.arrowLabel,
-            })),
+            elements: subDiagram.elements.map((element: any) => {
+              if (element.$type === 'TreeNodeDefinition') {
+                return {
+                  nodeDefinition: {
+                    nodeId: element.nodeId,
+                    value: element.value,
+                    color: element.color,
+                    arrow: element.arrowLabel !== undefined && element.arrowLabel !== null,
+                    arrowLabel: element.arrowLabel,
+                    hidden: (element.hidden || '').toLowerCase() === 'true',
+                  },
+                };
+              } else if (element.$type === 'TreeChildDefinition') {
+                return {
+                  childDefinition: {
+                    parent: element.parent,
+                    child: element.child,
+                  },
+                };
+              } else {
+                throw new Error(`Unknown tree element type: ${element.$type}`);
+              }
+            }),
           };
         case 'graph':
           return {

--- a/packages/mermaid/src/diagrams/visual/types.ts
+++ b/packages/mermaid/src/diagrams/visual/types.ts
@@ -93,7 +93,7 @@ export interface StackDiagram {
 }
 
 // Tree interfaces
-export interface TreeNode {
+export interface TreeNodeDefinition {
   nodeId: string;
   value?: string;
   color?: string;
@@ -102,21 +102,14 @@ export interface TreeNode {
   hidden?: boolean;
 }
 
-export interface TreeEdge {
-  start: string;
-  end: string;
-  value?: string;
-  color?: string;
+export interface TreeChildDefinition {
+  parent: string;
+  child: string;
 }
 
 export interface TreeElement {
-  nodeId: string;
-  value?: string;
-  color?: string;
-  arrow?: boolean;
-  arrowLabel?: string;
-  left: string;
-  right: string;
+  nodeDefinition?: TreeNodeDefinition;
+  childDefinition?: TreeChildDefinition;
 }
 
 export interface TreeDiagram {
@@ -124,7 +117,6 @@ export interface TreeDiagram {
   orientation?: string;
   title?: string;
   position?: PositionType;
-  //TODO: should be changed to required field
   elements?: TreeElement[];
   label?: string;
 }

--- a/packages/parser/src/language/visual/visual.langium
+++ b/packages/parser/src/language/visual/visual.langium
@@ -124,7 +124,15 @@ NodeID returns string:
 ;
 
 TreeElement:
-  nodeId=NodeID ':' '[' left=(NodeID | 'None') ',' right=(NodeID | 'None')']' ('{' 'value:' value=STRING (',' 'color:' color=STRING)?  (',' 'arrow:' arrowLabel=STRING)? (',' 'hidden:' hidden=STRING)?'}')? NEWLINE*
+  TreeNodeDefinition | TreeChildDefinition
+;
+
+TreeNodeDefinition:
+  type='node:' nodeId=NodeID ('{' 'value:' value=STRING (',' 'color:' color=STRING)? (',' 'arrow:' arrowLabel=STRING)? (',' 'hidden:' hidden=STRING)? '}')? NEWLINE*
+;
+
+TreeChildDefinition:
+  type='child:' '(' parent=NodeID ',' child=NodeID ')' NEWLINE*
 ;
 
 LinkedListDiagram:


### PR DESCRIPTION
New tree syntax!

# Features 
New we have this syntax allowing for more than just one child and we now have `removeSubtree()`:
```javascript
// Tree - Organizational hierarchy with dynamic restructuring
tree orgChart = {
	nodes: [CEO, CTO, CFO, LeadDev, Intern]
	value: ["Alice", "Bob", "Carol", "Dave", "Eve"]
	color: ["gold", "lightblue", "lightgreen", null, null]
	children: [CEO-CTO, CEO-CFO, CTO-LeadDev, LeadDev-Intern]
	arrow: [null,null,null,null,null]
}

page
show orgChart

page
orgChart.addChild(CFO-TechLead, "Frank")
orgChart.addChild(TechLead-Engineer, "Grace")
orgChart.setColor(TechLead, "lightcoral")
orgChart.setArrow(CEO, "CEO")

page
orgChart.setChild(CEO-TechLead)
orgChart.removeSubtree(Intern)
```